### PR TITLE
Remove use of cache when cache_active is False

### DIFF
--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -235,7 +235,10 @@ def _cached(f):
         cache = obj._cache
         prop = f.__name__
 
-        if not ((prop in cache) and obj._cache_active):
+        if not obj._cache_active:
+            return f(obj)
+
+        if prop not in cache:
             cache[prop] = f(obj)
 
         return cache[prop]


### PR DESCRIPTION
## Description

Cache dictionnary was used even if cache_active was set to False. It was computed every time and still use extra memory to store the result. I propose here to remove completly the use of this attribute when cache_active is False.

Resolve #7332

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

Summarize the introduced changes in the code block below in one or a few sentences. The
summary will be included in the next release notes automatically:

```release-note
In RegionProperties remove usage of cache when cache_active is set to False
```
